### PR TITLE
Replace Große Linde with Festhalle Durlach

### DIFF
--- a/src/restaurants.conf
+++ b/src/restaurants.conf
@@ -22,8 +22,8 @@
 </soliluna>
 
 <linde>
-  name = Große Linde
-  url  = http://www.grosse-linde-durlach.de/mittagstisch.html
+  name = Festhalle Durlach
+  url  = http://www.festhalle-durlach.de/speisen--getraenke_speisenkarte.php
   <xpath>
     menu        = //*[@id="middle-marker"]/div/h5[normalize-space()]
     description = //*[@id="middle-marker"]/div/div/h4


### PR DESCRIPTION
The whole team moved locations.
From http://www.festhalle-durlach.de/restaurant.php
"Ab Januar 2018 neues Restaurantteam in der Festhalle Durlach

Wolfgang Göhringer, seit 2010 Pächter des Restaurants „Große Linde“
in Durlach, davor einige Jahre in der Obermühle, übernimmt ab
Januar 2018 mit seinen Mitarbeitern das Restaurant der Festhalle
Durlach. Da in der Großen Linde Umbauten in größerem Maße
stattfinden werden, war ein Verbleib dort für ihn nicht mehr
möglich."

Without XPath updates.