### PR TITLE
Remove Curry'n Roll entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ The following restaurants are currently covered:
 - Bambusgarten
 - Borsalino
 - Cafe Galerie
-- Curry'n'Roll
 - Da Pino
 - Große Linde
 - Hanoi

--- a/src/restaurants.conf
+++ b/src/restaurants.conf
@@ -62,16 +62,6 @@
   spacer = qr(^\s*(von|Mittagstisch))
 </abseits>
 
-<curry_n_roll>
-  name = Curry'n Roll
-  url  = http://curryandroll.de/index.php/special-of-the-week
-  <xpath>
-    menu = //*[@id="restaurant"]/section/div/div/article/div/div/*[self::h2 or self::h3]
-    description = //*[@id="restaurant"]/section/div/div/article/div/header/h2
-  </xpath>
-  type = html
-</curry_n_roll>
-
 <bambus>
   name = Bambus-Garten
   url = http://bambus-garten.com/


### PR DESCRIPTION
From https://curryandroll.de/index.php/:
"Sehr geehrte Damen und Herren, wir sind sesshaft geworden.
Nach drei schönen und anstrengenden Jahren sind wir nun vom Curry´n Roll
- Foodtrailer zum AUMER Wirtshaus gewechselt."