### PR TITLE
Remove abseits

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ The following system binaries are required:
 
 The following restaurants are currently covered:
 
-- Abseits
 - Alte Durlacher Brauerei
 - American Diner
 - Aslan

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following restaurants are currently covered:
 - Borsalino
 - Cafe Galerie
 - Da Pino
-- Große Linde
+- Festhalle
 - Hanoi
 - Indian Rasoi
 - Maharani

--- a/src/restaurants.conf
+++ b/src/restaurants.conf
@@ -55,13 +55,6 @@
   type = pdf
 </vogel>
 
-<abseits>
-  name = Abseits
-  url = http://www.abseits-durlach.de/tagesessen.pdf
-  type = pdf
-  spacer = qr(^\s*(von|Mittagstisch))
-</abseits>
-
 <bambus>
   name = Bambus-Garten
   url = http://bambus-garten.com/


### PR DESCRIPTION
> Es eröffnete 2009 und schloss zum 29.03.2018 seine Pforten. Das Gebäude wird abgerissen und das Haus links daneben vergrößert.

    
Source: https://ka.stadtwiki.net/Abseits
